### PR TITLE
fix: incorrect comment on Math.sign

### DIFF
--- a/src/Core__Math.resi
+++ b/src/Core__Math.resi
@@ -788,7 +788,7 @@ See [`Math.sign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 
 ```rescript
 Math.sign(3.0) // 1.0
-Math.sign(-3.0) // 1.0
+Math.sign(-3.0) // -1.0
 Math.sign(0.0) // 0.0
 ```
 */


### PR DESCRIPTION
<img width="132" alt="image" src="https://github.com/user-attachments/assets/e2410ea7-3568-42b0-beef-3b6d012dddad">


Math.sign(negative_value) should be -1.0 instead of 1.0